### PR TITLE
Add README for installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# MyUCLouvain Dashboard Customizer Extension
+
+This Firefox extension is designed to enhance the user experience on the new **MyUCLouvain** dashboard by performing two main functions:
+
+1. **Remove the News Panel**: This extension hides the news panel that appears on the homepage, providing a cleaner and more streamlined layout.
+2. **Add Loading Animation**: It adds a simple loading animation to indicate when widgets are loading on the website, improving the visual feedback for users.
+
+This extension is self-hosted, and the `.xpi` file is available in the GitHub releases section.
+
+## Installation
+
+### Desktop (Firefox)
+
+1. **Download the Extension**:
+   - Visit the [Releases page](https://github.com/Vo-Alex/UCL-noNews/releases) on GitHub.
+   - Download the `.xpi` file for the latest release.
+   
+2. **Install the Extension**:
+   - Open Firefox and navigate to `about:addons` (or click the hamburger menu > Add-ons).
+   - Drag and drop the `.xpi` file into the Firefox window, or click the **Install Add-on from file...** button from the **Tools** dialog.
+   - You will be prompted to confirm the installation; click **Add** to install the extension.
+   
+3. **Enable the Extension**:
+   - Once installed, make sure the extension is enabled in the `about:addons` section. You can customize its settings or disable it from here if needed.
+
+### Mobile (Firefox for Android)
+
+1. **Enable Debug Mode**:
+   - Before you can install an extension from a file on Firefox for Android, you need to enable **Debug mode**.
+   - To do this, open Firefox for Android > Settings > About Firefox and click multiple times on the Firefox logo.
+   - When you go back, you will now see under Advanced section a **Install extension from file** button.
+   - This will allow you to install extensions from files on your device.
+
+2. **Download the Extension**:
+   - Go to the [Releases page](https://github.com/Vo-Alex/UCL-noNews/releases) on GitHub.
+   - Download the `.xpi` file for the latest release to your mobile device.
+
+3. **Install the Extension**:
+   - Open Firefox for Android > Settings.
+   - Click on **Install extension from file** under the Advanced section.
+   - Locate the downloaded `.xpi` file and tap it to start the installation.
+   - Confirm the installation when prompted.
+
+4. **Enable the Extension**:
+   - Once installed, ensure the extension is enabled by navigating to the **Extensions** section in Firefox for Android.
+
+> **Note**: Mobile Firefox extensions are less stable than desktop extensions, and may not always work as expected across all mobile devices.
+
+## Troubleshooting
+
+- **If the extension does not work after installation**:
+  - Try restarting Firefox (both on desktop or mobile).
+  - Ensure that no other conflicting extensions are interfering with the functionality of this one.
+
+- **If the loading animation or news panel removal doesn’t work**:
+  - Make sure you're visiting the latest version of the MyUCLouvain website.
+  - Check if there are any updates to the extension by visiting the GitHub releases page.
+
+## Contributing
+
+Feel free to fork this repository and submit pull requests if you want to contribute to this project. Please open an issue if you encounter any bugs or have suggestions for improvement.
+
+## Disclaimer
+
+This extension is provided as-is and is not officially supported by UCLouvain or any associated institutions. Use at your own discretion.


### PR DESCRIPTION
This pull request adds a detailed README.md file to the repository, outlining the purpose of the extension, its features, and clear installation instructions for both desktop and mobile Firefox users.

Changes include:

- Descriptions of the extension's functionality (removes the news panel and adds a loading animation on the MyUCLouvain dashboard).
- Step-by-step installation guides for Firefox Desktop and Mobile, including the need to enable Debug mode on mobile devices.
- Troubleshooting tips and contributing information.

This README aims to provide users with all the information they need to get started with the extension.
